### PR TITLE
[docker] Socket's location specification option

### DIFF
--- a/pipework
+++ b/pipework
@@ -34,6 +34,13 @@ if [ "$2" = "-a" ]; then
   shift 2
 fi
 
+#docker socket specification
+DOCKER_SOCKET=
+if [ "$2" = "-H" ]; then
+  DOCKER_SOCKET="-H $3"
+  shift 2
+fi
+
 GUESTNAME=$2
 IPADDR=$3
 MACADDR=$4
@@ -62,8 +69,8 @@ esac
 
 [ "$IPADDR" ] || [ "$WAIT" ] || {
   echo "Syntax:"
-  echo "pipework <hostinterface> [-i containerinterface] [-l localinterfacename] [-a addressfamily] <guest> <ipaddr>/<subnet>[@default_gateway] [macaddr][@vlan]"
-  echo "pipework <hostinterface> [-i containerinterface] [-l localinterfacename] <guest> dhcp [macaddr][@vlan]"
+  echo "pipework <hostinterface> [-i containerinterface] [-l localinterfacename] [-a addressfamily] [-H dockersocket] <guest> <ipaddr>/<subnet>[@default_gateway] [macaddr][@vlan]"
+  echo "pipework <hostinterface> [-i containerinterface] [-l localinterfacename] [-H dockersocket] <guest> dhcp [macaddr][@vlan]"
   echo "pipework route <guest> <route_command>"
   echo "pipework --wait [-i containerinterface]"
   exit 1


### PR DESCRIPTION
Added a new "-H" parameter to allow to specify the location of the Docker's socket. This option is useful in set-ups where multiple instances of dockerd are running on the same host and it's necessary to select the socket's location to talk with the correct daemon.
